### PR TITLE
feat: expand item info across tabs

### DIFF
--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -821,9 +821,15 @@ function Atr_Init()
 	recommendElements[2] = getglobal ("Atr_RecommendPerItem_Text");
 	recommendElements[3] = getglobal ("Atr_RecommendPerItem_Price");
 	recommendElements[4] = getglobal ("Atr_RecommendPerStack_Text");
-	recommendElements[5] = getglobal ("Atr_RecommendPerStack_Price");
-	recommendElements[6] = getglobal ("Atr_Recommend_Basis_Text");
-	recommendElements[7] = getglobal ("Atr_RecommendItem_Tex");
+        recommendElements[5] = getglobal ("Atr_RecommendPerStack_Price");
+        recommendElements[6] = getglobal ("Atr_Recommend_Basis_Text");
+        recommendElements[7] = getglobal ("Atr_RecommendItem_Tex");
+
+        Atr_RecommendPerItem_Text:Hide();
+        Atr_RecommendPerItem_Price:Hide();
+        Atr_RecommendPerStack_Text:Hide();
+        Atr_RecommendPerStack_Price:Hide();
+        Atr_Recommend_Basis_Text:Hide();
 	
 	-- Initialize cache age display as hidden
 	if (Atr_CacheAge_Text) then
@@ -1870,10 +1876,19 @@ function Atr_ClearCurrent()
 		gCurrentPane.activeScan = Atr_FindScan(nil);
 	end
 	
-	-- Clear the recommendation text
-	if (Atr_Recommend_Text) then
-		Atr_Recommend_Text:SetText("");
-	end
+        -- Clear the recommendation text
+        if (Atr_Recommend_Text) then
+                Atr_Recommend_Text:SetText("");
+        end
+
+        if (Atr_ItemInfo_Total_Text) then
+                Atr_ItemInfo_Total_Text:SetText("");
+                if Atr_ItemInfo_Auc_Text then Atr_ItemInfo_Auc_Text:SetText(""); end
+                Atr_ItemInfo_Median_Text:SetText("");
+                Atr_ItemInfo_P5_Text:SetText("");
+                Atr_ItemInfo_P10_Text:SetText("");
+                Atr_ItemInfo_P25_Text:SetText("");
+        end
 	
 	-- Clear any current message
 	Atr_SetMessage("");
@@ -2190,15 +2205,92 @@ end
 
 
 
+
+-----------------------------------------
+
+local function Atr_GetPricePercentile(scan, pct)
+        if not scan then return nil end
+        local total = 0
+        for i = 1, #scan.sortedData do
+                local data = scan.sortedData[i]
+                if data.itemPrice > 0 then
+                        total = total + data.count * data.stackSize
+                end
+        end
+        if total == 0 then return nil end
+        local target = math.ceil(total * pct / 100)
+        local count = 0
+        for i = 1, #scan.sortedData do
+                local data = scan.sortedData[i]
+                if data.itemPrice > 0 then
+                        count = count + data.count * data.stackSize
+                        if count >= target then
+                                return data.itemPrice
+                        end
+                end
+        end
+        return nil
+end
+
+function Atr_UpdateItemInfo()
+        local pane = gCurrentPane
+        local scan = pane and pane.activeScan
+        if not scan or not Atr_ItemInfo_Total_Text then return end
+
+        local function clear()
+                Atr_ItemInfo_Total_Text:SetText("")
+                if Atr_ItemInfo_Auc_Text then Atr_ItemInfo_Auc_Text:SetText("") end
+                Atr_ItemInfo_Median_Text:SetText("")
+                Atr_ItemInfo_P5_Text:SetText("")
+                Atr_ItemInfo_P10_Text:SetText("")
+                Atr_ItemInfo_P25_Text:SetText("")
+        end
+
+        if pane:GetProcessingState() ~= KM_NULL_STATE or #scan.sortedData == 0 then
+                clear()
+                return
+        end
+
+        local totalAuctions = 0
+        for i = 1, #scan.sortedData do
+                totalAuctions = totalAuctions + scan.sortedData[i].count
+        end
+
+        local totalItems = scan:GetNumAvailable()
+        local median = Atr_GetPricePercentile(scan, 50)
+        local p05 = Atr_GetPricePercentile(scan, 5)
+        local p10 = Atr_GetPricePercentile(scan, 10)
+        local p25 = Atr_GetPricePercentile(scan, 25)
+
+        local function lbl(t)
+                return string.format("%-5s", t)
+        end
+
+        Atr_ItemInfo_Total_Text:SetText(string.format("всего %d предметов", totalItems))
+        if Atr_ItemInfo_Auc_Text then
+                Atr_ItemInfo_Auc_Text:SetText(string.format("всего %d аукционов", totalAuctions))
+        end
+        Atr_ItemInfo_Median_Text:SetText(lbl("m:")..(median and zc.priceToMoneyString(median) or "—"))
+        Atr_ItemInfo_P5_Text:SetText(lbl("p05:")..(p05 and zc.priceToMoneyString(p05) or "—"))
+        Atr_ItemInfo_P10_Text:SetText(lbl("p10:")..(p10 and zc.priceToMoneyString(p10) or "—"))
+        Atr_ItemInfo_P25_Text:SetText(lbl("p25:")..(p25 and zc.priceToMoneyString(p25) or "—"))
+end
+
 -----------------------------------------
 
 function Atr_UpdateRecommendation (updatePrices)
 
-	if (gCurrentPane == gSellPane and gJustPosted_ItemLink and GetAuctionSellItemInfo() == nil) then
-		return;
-	end
+        if (gCurrentPane == gSellPane and gJustPosted_ItemLink and GetAuctionSellItemInfo() == nil) then
+                return;
+        end
 
-	local basedata;
+        local scn = gCurrentPane.activeScan;
+        if (not scn) then
+                return;
+        end
+        Atr_UpdateItemInfo();
+
+        local basedata;
 
 	if (Atr_ShowingSearchSummary()) then
 	
@@ -2274,38 +2366,32 @@ function Atr_UpdateRecommendation (updatePrices)
 	
 	local new_Item_StartPrice = Atr_CalcStartPrice (new_Item_BuyoutPrice);
 
-	--Atr_ShowElems (recommendElements);
-	AuctionatorMessageFrame:Hide();
-	AuctionatorMessage2Frame:Hide();
+        --Atr_ShowElems (recommendElements);
+        AuctionatorMessageFrame:Hide();
+        AuctionatorMessage2Frame:Hide();
 
-	Atr_Recommend_Text:SetText (ZT("Recommended Buyout Price"));
-	Atr_RecommendPerStack_Text:SetText (string.format (ZT("for your stack of %d"), Atr_StackSize()));
+        local color = "";
+        if (not scn:IsNil()) then
+                color = "|cff"..zc.RGBtoHEX (scn.itemTextColor[1], scn.itemTextColor[2], scn.itemTextColor[3]);
+        end
+        Atr_Recommend_Text:SetText (color..scn.itemName);
 
-	Atr_SetTextureButton ("Atr_RecommendItem_Tex", Atr_StackSize(), gCurrentPane.activeScan.itemLink);
+        Atr_SetTextureButton ("Atr_RecommendItem_Tex", Atr_StackSize(), scn.itemLink);
 
-	MoneyFrame_Update ("Atr_RecommendPerItem_Price",  zc.round(new_Item_BuyoutPrice));
-	MoneyFrame_Update ("Atr_RecommendPerStack_Price", zc.round(new_Item_BuyoutPrice * Atr_StackSize()));
+        Atr_RecommendPerStack_Text:Hide();
+        Atr_RecommendPerItem_Text:Hide();
+        Atr_RecommendPerStack_Price:Hide();
+        Atr_RecommendPerItem_Price:Hide();
+        Atr_Recommend_Basis_Text:Hide();
 
-	if (updatePrices) then
-		MoneyInputFrame_SetCopper (Atr_StackPrice,		new_Item_BuyoutPrice * Atr_StackSize());
-		MoneyInputFrame_SetCopper (Atr_StartingPrice, 	new_Item_StartPrice * Atr_StackSize());
-		MoneyInputFrame_SetCopper (Atr_ItemPrice,		new_Item_BuyoutPrice);
-	end
-	
-	local cheapestStack = gCurrentPane.activeScan.bestPrices[Atr_StackSize()];
+        if (updatePrices) then
+                MoneyInputFrame_SetCopper (Atr_StackPrice,              new_Item_BuyoutPrice * Atr_StackSize());
+                MoneyInputFrame_SetCopper (Atr_StartingPrice,   new_Item_StartPrice * Atr_StackSize());
+                MoneyInputFrame_SetCopper (Atr_ItemPrice,               new_Item_BuyoutPrice);
+        end
 
-	Atr_Recommend_Basis_Text:SetTextColor (1,1,1);
+        Atr_UpdateCacheAgeDisplay();
 
-	if (Atr_ShowingHints()) then
-		Atr_Recommend_Basis_Text:SetTextColor (.8,.8,1);
-		Atr_Recommend_Basis_Text:SetText ("("..ZT("based on").." "..basedata.sourceText..")");
-	elseif (gCurrentPane.activeScan.absoluteBest and basedata.stackSize == gCurrentPane.activeScan.absoluteBest.stackSize and basedata.buyoutPrice == gCurrentPane.activeScan.absoluteBest.buyoutPrice) then
-		Atr_Recommend_Basis_Text:SetText ("("..ZT("based on cheapest current auction")..")");
-	elseif (cheapestStack and basedata.stackSize == cheapestStack.stackSize and basedata.buyoutPrice == cheapestStack.buyoutPrice) then
-		Atr_Recommend_Basis_Text:SetText ("("..ZT("based on cheapest stack of the same size")..")");
-	else
-		Atr_Recommend_Basis_Text:SetText ("("..ZT("based on selected auction")..")");
-	end
 
 end
 

--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -22,8 +22,8 @@ BROWSE_COLUMNS = {
   {name = "Owner",      width = 80,  heading = "Seller"},
 }
 
-local browseSortCol = "PerItem"
-local browseSortAsc = true
+browseSortCol = "PerItem"
+browseSortAsc = true
 
 local gSellPriceCache = {}
 

--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -4089,18 +4089,16 @@ function Atr_EntryOnClick()
 	else												gCurrentPane.hintsIndex = entryIndex;
 	end
 
-	if (Atr_ShowingSearchSummary()) then
-		local scn = gCurrentPane.activeSearch.sortedScans[entryIndex];
-
-		FauxScrollFrame_SetOffset (AuctionatorScrollFrame, 0);
-		gCurrentPane.activeScan = scn;
-		gCurrentPane.currIndex = scn:FindMatchByYours ();
-		gCurrentPane.SS_hilite_itemName = scn.itemName;
-		gCurrentPane.UINeedsUpdate = true;
-	else
-		Atr_HighlightEntry (entryIndex);
-		Atr_UpdateRecommendation(true);
-	end
+       if (Atr_ShowingSearchSummary()) then
+               local scn = gCurrentPane.activeSearch.sortedScans[entryIndex]
+               if scn then
+                       Atr_Search_Box:SetText(scn.itemName)
+                       gCurrentPane:DoSearch(scn.itemName, true, AUCTIONATOR_CACHE_THRESHOLD)
+               end
+       else
+               Atr_HighlightEntry (entryIndex);
+               Atr_UpdateRecommendation(true);
+       end
 
 	PlaySound ("igMainMenuOptionCheckBoxOn");
 end

--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -92,6 +92,23 @@ function Atr_BuildBrowseHeaders(parent)
 end
 
 function Atr_BuildBrowseEntry(row)
+  -- Item name column used by search summary and history lists
+  local entry = CreateFrame("Frame", row:GetName() .. "_Entry", row)
+  entry:SetSize(150, 16)
+  entry:SetPoint("LEFT", row, "LEFT", 0, 0)
+
+  local entryText = entry:CreateFontString(row:GetName() .. "_EntryText", "BACKGROUND", "GameFontHighlightSmall")
+  entryText:SetPoint("LEFT", entry, "LEFT", 0, 1)
+  entryText:SetWidth(150)
+  entryText:SetJustifyH("LEFT")
+  entryText:SetWordWrap(false)
+
+  local stack = entry:CreateFontString(row:GetName() .. "_StackPrice", "BACKGROUND", "GameFontHighlightSmall")
+  stack:SetPoint("LEFT", entry, "RIGHT", 4, 1)
+  stack:SetWidth(120)
+  stack:SetJustifyH("LEFT")
+  stack:SetWordWrap(false)
+
   local prev
   for _, col in ipairs(BROWSE_COLUMNS) do
     local frame = CreateFrame("Frame", row:GetName() .. "_" .. col.name, row)

--- a/Auctionator.xml
+++ b/Auctionator.xml
@@ -264,7 +264,7 @@
 					</Font>
 				</FontString>
 
-				<FontString name="Atr_Recommend_Text" inherits="GameFontNormal" text="Recommended buyout price">
+                                <FontString name="Atr_Recommend_Text" inherits="GameFontNormal" text="">
 					<Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="77" y="-98"/></Offset></Anchor></Anchors>
 				</FontString>
 
@@ -280,15 +280,39 @@
 					<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="152" y="-51"/></Offset></Anchor></Anchors>
 				</FontString>
 
-				<FontString name="Atr_CacheAge_Text" inherits="GameFontHighlightSmall" text="">
-					<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="0" y="-20"/></Offset></Anchor></Anchors>
-					<Font>
-						<Color r="0.7" g="0.7" b="0.7"/>
-					</Font>
-				</FontString>
-			</Layer>
+                                <FontString name="Atr_CacheAge_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="0" y="-20"/></Offset></Anchor></Anchors>
+                                        <Font>
+                                                <Color r="0.7" g="0.7" b="0.7"/>
+                                        </Font>
+                                </FontString>
 
-		</Layers>
+                                <FontString name="Atr_ItemInfo_Total_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_CacheAge_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                                <FontString name="Atr_ItemInfo_Auc_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Total_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                                <FontString name="Atr_ItemInfo_Median_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Auc_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                                <FontString name="Atr_ItemInfo_P5_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Total_Text"><Offset><AbsDimension x="160" y="0"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                <FontString name="Atr_ItemInfo_P10_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_P5_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                                <FontString name="Atr_ItemInfo_P25_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_P10_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+                        </Layer>
+
+                </Layers>
 
 
 

--- a/Auctionator.xml
+++ b/Auctionator.xml
@@ -264,8 +264,8 @@
 					</Font>
 				</FontString>
 
-                                <FontString name="Atr_Recommend_Text" inherits="GameFontNormal" text="">
-					<Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="77" y="-98"/></Offset></Anchor></Anchors>
+                <FontString name="Atr_Recommend_Text" inherits="GameFontNormal" text="">
+					<Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="77" y="-82"/></Offset></Anchor></Anchors>
 				</FontString>
 
 				<FontString name="Atr_Recommend_Basis_Text" inherits="GameFontHighlightSmall" text="based on">
@@ -280,39 +280,39 @@
 					<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="152" y="-51"/></Offset></Anchor></Anchors>
 				</FontString>
 
-                                <FontString name="Atr_CacheAge_Text" inherits="GameFontHighlightSmall" text="">
-                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="0" y="-20"/></Offset></Anchor></Anchors>
-                                        <Font>
-                                                <Color r="0.7" g="0.7" b="0.7"/>
-                                        </Font>
-                                </FontString>
+				<FontString name="Atr_CacheAge_Text" inherits="GameFontHighlightSmall" text="">
+						<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="0" y="-20"/></Offset></Anchor></Anchors>
+						<Font>
+								<Color r="0.7" g="0.7" b="0.7"/>
+						</Font>
+				</FontString>
 
-                                <FontString name="Atr_ItemInfo_Total_Text" inherits="GameFontHighlightSmall" text="">
-                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_CacheAge_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
-                                </FontString>
+				<FontString name="Atr_ItemInfo_Total_Text" inherits="GameFontHighlightSmall" text="">
+						<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_CacheAge_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+				</FontString>
 
-                                <FontString name="Atr_ItemInfo_Auc_Text" inherits="GameFontHighlightSmall" text="">
-                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Total_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
-                                </FontString>
+				<FontString name="Atr_ItemInfo_Auc_Text" inherits="GameFontHighlightSmall" text="">
+						<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Total_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+				</FontString>
 
-                                <FontString name="Atr_ItemInfo_Median_Text" inherits="GameFontHighlightSmall" text="">
-                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Auc_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
-                                </FontString>
+				<FontString name="Atr_ItemInfo_Median_Text" inherits="GameFontHighlightSmall" text="">
+						<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Auc_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+				</FontString>
 
-                                <FontString name="Atr_ItemInfo_P5_Text" inherits="GameFontHighlightSmall" text="">
-                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Total_Text"><Offset><AbsDimension x="160" y="0"/></Offset></Anchor></Anchors>
-                                </FontString>
+				<FontString name="Atr_ItemInfo_P5_Text" inherits="GameFontHighlightSmall" text="">
+						<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Total_Text"><Offset><AbsDimension x="160" y="0"/></Offset></Anchor></Anchors>
+				</FontString>
 
                 <FontString name="Atr_ItemInfo_P10_Text" inherits="GameFontHighlightSmall" text="">
-                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_P5_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
-                                </FontString>
+						<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_P5_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+				</FontString>
 
-                                <FontString name="Atr_ItemInfo_P25_Text" inherits="GameFontHighlightSmall" text="">
-                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_P10_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
-                                </FontString>
-                        </Layer>
+				<FontString name="Atr_ItemInfo_P25_Text" inherits="GameFontHighlightSmall" text="">
+						<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_P10_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+				</FontString>
+			</Layer>
 
-                </Layers>
+		</Layers>
 
 
 

--- a/AuctionatorPane.lua
+++ b/AuctionatorPane.lua
@@ -71,6 +71,14 @@ function AtrPane:DoSearch (searchText, exact, rescanThreshold, callback)
 		else
 			self.UINeedsUpdate = true;
 			cacheHit = true;
+
+			if (self.activeScan.sortedData) then
+				table.sort(self.activeScan.sortedData, Atr_SortAuctionData);
+			end
+
+			browseSortCol = "PerItem";
+			browseSortAsc = true;
+			Atr_UpdateBrowseArrows();
 		end
 	end
 	

--- a/AuctionatorPane.lua
+++ b/AuctionatorPane.lua
@@ -52,6 +52,10 @@ function AtrPane:DoSearch (searchText, exact, rescanThreshold, callback)
 	Atr_ClearAll();		-- it's fast, might as well just do it now for cleaner UE
 	
 	self.UINeedsUpdate = false;		-- will be set when scan finishes
+
+	browseSortCol = "PerItem";	-- reset sort state for new searches
+	browseSortAsc = true;
+	Atr_UpdateBrowseArrows();
 			
 	self.activeSearch = Atr_NewSearch (searchText, exact, rescanThreshold, callback);
 	
@@ -70,6 +74,7 @@ function AtrPane:DoSearch (searchText, exact, rescanThreshold, callback)
 		end
 	end
 	
+	Atr_UpdateItemInfo();
 	return cacheHit;
 end
 

--- a/AuctionatorScan.lua
+++ b/AuctionatorScan.lua
@@ -765,13 +765,13 @@ function AtrScan:CondenseAndSort ()
 			dataType = "a";
 		end
 
-		local key = "_".. sd.stackSize 
-			.."_".. sd.buyoutPrice 
-			.."_".. sd.nextBid 
-			.."_".. sd.timeLeft 
-			.."_".. tostring(sd.highBidder)
-			.."_".. ownerCode 
-			.."_".. dataType;
+                local key = "_".. (sd.stackSize or 0)
+                        .."_".. (sd.buyoutPrice or 0)
+                        .."_".. (sd.nextBid or 0)
+                        .."_".. (sd.timeLeft or 0)
+                        .."_".. tostring(sd.highBidder)
+                        .."_".. ownerCode
+                        .."_".. dataType;
 
 		if (conddata[key]) then
 			conddata[key].count		= conddata[key].count + 1;
@@ -789,15 +789,15 @@ function AtrScan:CondenseAndSort ()
 			data.stackSize 		= sd.stackSize;
 			data.buyoutPrice	= sd.buyoutPrice;
 			data.itemPrice		= sd.buyoutPrice / sd.stackSize;
-			data.nextBid		= sd.nextBid;
-			data.nextBidPerItem	= sd.nextBid / sd.stackSize;  -- Calculate bid price per item
+			data.nextBid            = sd.nextBid or 0;
+                        data.nextBidPerItem     = (sd.nextBid or 0) / sd.stackSize;  -- Calculate bid price per item
 			data.minpage		= sd.pagenum;
 			data.maxpage		= sd.pagenum;
 			data.count			= 1;
 			data.type			= dataType;
 			data.yours			= (ownerCode == "y");
 			data.hasActiveBids	= sd.hasActiveBids;
-			data.timeLeft		= sd.timeLeft;
+			data.timeLeft           = sd.timeLeft or 0;
 			data.timeLeftStr = ({ "0m +", "30m ++", "2h +++", "12h ++++" })[sd.timeLeft or 0] or "???"
 			data.owner			= sd.owner;
 			data.highBidder	= sd.highBidder;

--- a/AuctionatorShop.lua
+++ b/AuctionatorShop.lua
@@ -250,13 +250,15 @@ function Atr_Shop_OnFinishScan ()
 		
 	end
 
-	if (#currentPane.activeScan.sortedData > 0) then
-		currentPane.currIndex = 1;
-	end
+        if (#currentPane.activeScan.sortedData > 0) then
+                currentPane.currIndex = 1;
+        end
 
-	currentPane.UINeedsUpdate = true;
-	
-	Atr_Search_Button:Enable();
+        Atr_UpdateItemInfo();
+
+        currentPane.UINeedsUpdate = true;
+
+        Atr_Search_Button:Enable();
 end
 
 


### PR DESCRIPTION
## Summary
- compute and display item count, auction count, median, and price percentiles in item info panel
- update recommendation logic and shop scan to show these stats on buy and sell tabs
- ignore zero-buyout auctions when calculating percentiles
- realign median and percentile columns and hide stats while scans are running

## Testing
- `luac -p Auctionator.lua AuctionatorShop.lua`


------
https://chatgpt.com/codex/tasks/task_e_6891c39349b08326a7538779c49d02e5