### PR TITLE
feat: expand item info across tabs

### DIFF
--- a/Auctionator.xml
+++ b/Auctionator.xml
@@ -264,9 +264,9 @@
 					</Font>
 				</FontString>
 
-				<FontString name="Atr_Recommend_Text" inherits="GameFontNormal" text="Recommended buyout price">
-					<Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="77" y="-98"/></Offset></Anchor></Anchors>
-				</FontString>
+                                <FontString name="Atr_Recommend_Text" inherits="GameFontNormal" text="">
+                                        <Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="77" y="-82"/></Offset></Anchor></Anchors>
+                                </FontString>
 
 				<FontString name="Atr_Recommend_Basis_Text" inherits="GameFontHighlightSmall" text="based on">
 					<Anchors><Anchor point="LEFT" relativePoint="RIGHT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="20" y="-2"/></Offset></Anchor></Anchors>
@@ -280,15 +280,39 @@
 					<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="152" y="-51"/></Offset></Anchor></Anchors>
 				</FontString>
 
-				<FontString name="Atr_CacheAge_Text" inherits="GameFontHighlightSmall" text="">
-					<Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="0" y="-20"/></Offset></Anchor></Anchors>
-					<Font>
-						<Color r="0.7" g="0.7" b="0.7"/>
-					</Font>
-				</FontString>
-			</Layer>
+                                <FontString name="Atr_CacheAge_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Recommend_Text"><Offset><AbsDimension x="0" y="-20"/></Offset></Anchor></Anchors>
+                                        <Font>
+                                                <Color r="0.7" g="0.7" b="0.7"/>
+                                        </Font>
+                                </FontString>
 
-		</Layers>
+                                <FontString name="Atr_ItemInfo_Total_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_CacheAge_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                                <FontString name="Atr_ItemInfo_Auc_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Total_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                                <FontString name="Atr_ItemInfo_Median_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Auc_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                                <FontString name="Atr_ItemInfo_P5_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_Total_Text"><Offset><AbsDimension x="160" y="0"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                <FontString name="Atr_ItemInfo_P10_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_P5_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+
+                                <FontString name="Atr_ItemInfo_P25_Text" inherits="GameFontHighlightSmall" text="">
+                                        <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_ItemInfo_P10_Text"><Offset><AbsDimension x="0" y="-15"/></Offset></Anchor></Anchors>
+                                </FontString>
+                        </Layer>
+
+                </Layers>
 
 
 

--- a/AuctionatorScan.lua
+++ b/AuctionatorScan.lua
@@ -765,13 +765,13 @@ function AtrScan:CondenseAndSort ()
 			dataType = "a";
 		end
 
-		local key = "_".. sd.stackSize 
-			.."_".. sd.buyoutPrice 
-			.."_".. sd.nextBid 
-			.."_".. sd.timeLeft 
-			.."_".. tostring(sd.highBidder)
-			.."_".. ownerCode 
-			.."_".. dataType;
+                local key = "_".. (sd.stackSize or 0)
+                        .."_".. (sd.buyoutPrice or 0)
+                        .."_".. (sd.nextBid or 0)
+                        .."_".. (sd.timeLeft or 0)
+                        .."_".. tostring(sd.highBidder)
+                        .."_".. ownerCode
+                        .."_".. dataType;
 
 		if (conddata[key]) then
 			conddata[key].count		= conddata[key].count + 1;
@@ -789,15 +789,15 @@ function AtrScan:CondenseAndSort ()
 			data.stackSize 		= sd.stackSize;
 			data.buyoutPrice	= sd.buyoutPrice;
 			data.itemPrice		= sd.buyoutPrice / sd.stackSize;
-			data.nextBid		= sd.nextBid;
-			data.nextBidPerItem	= sd.nextBid / sd.stackSize;  -- Calculate bid price per item
+			data.nextBid            = sd.nextBid or 0;
+                        data.nextBidPerItem     = (sd.nextBid or 0) / sd.stackSize;  -- Calculate bid price per item
 			data.minpage		= sd.pagenum;
 			data.maxpage		= sd.pagenum;
 			data.count			= 1;
 			data.type			= dataType;
 			data.yours			= (ownerCode == "y");
 			data.hasActiveBids	= sd.hasActiveBids;
-			data.timeLeft		= sd.timeLeft;
+			data.timeLeft           = sd.timeLeft or 0;
 			data.timeLeftStr = ({ "0m +", "30m ++", "2h +++", "12h ++++" })[sd.timeLeft or 0] or "???"
 			data.owner			= sd.owner;
 			data.highBidder	= sd.highBidder;

--- a/AuctionatorShop.lua
+++ b/AuctionatorShop.lua
@@ -250,13 +250,15 @@ function Atr_Shop_OnFinishScan ()
 		
 	end
 
-	if (#currentPane.activeScan.sortedData > 0) then
-		currentPane.currIndex = 1;
-	end
+        if (#currentPane.activeScan.sortedData > 0) then
+                currentPane.currIndex = 1;
+        end
 
-	currentPane.UINeedsUpdate = true;
-	
-	Atr_Search_Button:Enable();
+        Atr_UpdateItemInfo();
+
+        currentPane.UINeedsUpdate = true;
+
+        Atr_Search_Button:Enable();
 end
 
 
@@ -501,11 +503,11 @@ function Atr_Shop_UpdateUI ()
 		
 	end
 	
-	if (currentPane.activeSearch:NumScans() > 1 and not currentPane:IsScanEmpty()) then
-		Atr_Back_Button:Show();
-	else
-		Atr_Back_Button:Hide();
-	end
+        if (currentPane.searchSummary or (currentPane.activeSearch:NumScans() > 1 and not currentPane:IsScanEmpty())) then
+                Atr_Back_Button:Show();
+        else
+                Atr_Back_Button:Hide();
+        end
 	
 end
 


### PR DESCRIPTION
## Summary
- compute and display item count, auction count, median, and price percentiles in item info panel
- update recommendation logic and shop scan to show these stats on buy and sell tabs
- ignore zero-buyout auctions when calculating percentiles
- realign median and percentile columns and hide stats while scans are running
- reset browse sort and hide stale stats when searches change
- reuse cached sell scans and retain user-entered prices
- reset browse sort and arrow when loading cached results for a new item
- prevent scan errors by defaulting missing timeLeft values to zero
- build browse entry text fields to avoid nil errors in search summary
- share browse sort state globally so switching items always reverts to buyout sort
- rerun an exact search when clicking a summary item so multiple results can be explored
- show item-search results as name/buyout pairs, restore a working Back button, and force fresh scans for new queries
- tweak item-info text offset in XML

## Testing
- `luac -p Auctionator.lua AuctionatorPane.lua AuctionatorShop.lua AuctionatorScan.lua`


------
https://chatgpt.com/codex/tasks/task_e_6891c39349b08326a7538779c49d02e5